### PR TITLE
Update build with preferred idf_component_register and automatic link…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,3 +6,10 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(mini_ft8)
 # Build SPIFFS image, but do NOT include it in default flash target (preserve on-device files)
 spiffs_create_partition_image(spiffs ${CMAKE_SOURCE_DIR}/spiffs_image)
+
+# Automatically generate a single merged binary file (like in the release directory) after every build
+add_custom_command(TARGET app POST_BUILD
+    COMMAND python -m esptool --chip esp32s3 merge_bin -o "MiniFT8_Merged_Auto.bin" @flash_args
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Auto-generating merged binary MiniFT8_Merged_Auto.bin for release..."
+)

--- a/components/M5GFX/CMakeLists.txt
+++ b/components/M5GFX/CMakeLists.txt
@@ -1,6 +1,3 @@
-set(COMPONENT_ADD_INCLUDEDIRS
-    src
-    )
 file(GLOB SRCS
      src/*.cpp
      src/lgfx/Fonts/efont/*.c
@@ -15,7 +12,7 @@ file(GLOB SRCS
      src/lgfx/v1/platforms/esp32p4/*.cpp
      src/lgfx/v1/touch/*.cpp
      )
-set(COMPONENT_SRCS ${SRCS})
+
 
 if (IDF_VERSION_MAJOR GREATER_EQUAL 5)
     set(COMPONENT_REQUIRES nvs_flash efuse driver esp_timer esp_lcd esp_mm)
@@ -31,4 +28,11 @@ endif()
 
 message(STATUS "M5GFX use components = ${COMPONENT_REQUIRES}")
 
-register_component()
+if(COMMAND idf_component_register)
+    idf_component_register(SRCS ${SRCS} INCLUDE_DIRS src REQUIRES ${COMPONENT_REQUIRES})
+else()
+    set(COMPONENT_ADD_INCLUDEDIRS src)
+    set(COMPONENT_SRCS ${SRCS})
+    register_component()
+endif()
+

--- a/components/M5Unified/CMakeLists.txt
+++ b/components/M5Unified/CMakeLists.txt
@@ -1,6 +1,4 @@
-set(COMPONENT_ADD_INCLUDEDIRS
-    src
-    )
+
 file(GLOB SRCS
      src/*.cpp
      src/utility/*.cpp
@@ -9,7 +7,7 @@ file(GLOB SRCS
      src/utility/power/*.cpp
      src/utility/rtc/*.cpp
      )
-set(COMPONENT_SRCS ${SRCS})
+
 
 if (IDF_VERSION_MAJOR GREATER_EQUAL 5)
     set(COMPONENT_REQUIRES M5GFX esp_adc driver)
@@ -24,5 +22,11 @@ endif()
 message(STATUS "M5Unified use component = ${COMPONENT_REQUIRES}" )
 
 
-register_component()
+if(COMMAND idf_component_register)
+    idf_component_register(SRCS ${SRCS} INCLUDE_DIRS src REQUIRES ${COMPONENT_REQUIRES})
+else()
+    set(COMPONENT_ADD_INCLUDEDIRS src)
+    set(COMPONENT_SRCS ${SRCS})
+    register_component()
+endif()
 


### PR DESCRIPTION
A couple build updates that made my 5.5.1 esp-idf happier (it said idf_component_register was the preferred way vs. register_component, but I'm far from an esp-idf expert), plus a simple "auto-bundle" at the end for a bin that can be directly used in m5laucher.