### PR TITLE
Minor updates to QMX CAT control

### DIFF
--- a/components/ui/CMakeLists.txt
+++ b/components/ui/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "ui.cpp"
-    INCLUDE_DIRS "include"
+    INCLUDE_DIRS "include" "."
     REQUIRES M5Unified M5GFX M5Cardputer
 )

--- a/main/radio_control_qmx.cpp
+++ b/main/radio_control_qmx.cpp
@@ -20,14 +20,19 @@ static esp_err_t qmx_send_cmd(const char* cmd, uint32_t timeout_ms) {
 }
 
 static esp_err_t qmx_sync_frequency_mode(int freq_hz) {
-    char fa[32];
-    snprintf(fa, sizeof(fa), "FA%011d;", freq_hz);
-
-    esp_err_t err = qmx_send_cmd(fa, 200);
+    const char* md = "MD6;";
+    esp_err_t err = qmx_send_cmd(md, 200);
     if (err != ESP_OK) return err;
 
-    const char* md = "MD6;";
-    err = qmx_send_cmd(md, 200);
+    err = qmx_send_cmd("FR0;", 200);
+    if (err != ESP_OK) return err;
+
+    err = qmx_send_cmd("FT0;", 200);
+    if (err != ESP_OK) return err;
+
+    char fa[32];
+    snprintf(fa, sizeof(fa), "FA%011d;", freq_hz);
+    err = qmx_send_cmd(fa, 200);
     if (err == ESP_OK) {
         ESP_LOGI(TAG, "QMX sync ok freq=%d", freq_hz);
     }


### PR DESCRIPTION
Discovered it was easy to accidentally get into VFO B and have things look like they're working (band switch works) but frequencies would be wrong. That's because the frequency changes went to VFO A.

Added a reset to ensure VFO A is selected on frequency update commands.