### PR TITLE
Pr 2 protocol cleanup

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -16,3 +16,20 @@ idf_component_register(
     REQUIRES ui M5Unified M5GFX M5Cardputer board_cardputer_adv ft8_lib usb_host_uac usb_host_cdc_acm fatfs sdmmc spiffs bt nvs_flash efuse json
 )
 target_compile_options(${COMPONENT_LIB} PRIVATE -Werror)
+
+# POST_BUILD DRAM budget check — fails the build if static free DIRAM falls
+# below the FT8 variant threshold (50 KB). Catches silent CDC-ACM allocation
+# failures caused by NimBLE consuming DRAM before we'd notice at runtime.
+# Override the variant with -DDRAM_CHECK_VARIANT=ft4 for the FT4 build.
+if(NOT DEFINED DRAM_CHECK_VARIANT)
+    set(DRAM_CHECK_VARIANT "ft8")
+endif()
+add_custom_command(TARGET ${COMPONENT_LIB} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo "[check_dram_budget] Running DRAM budget check (variant=${DRAM_CHECK_VARIANT})..."
+    COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_SOURCE_DIR}/tools/check_dram_budget.py
+            ${CMAKE_BINARY_DIR}
+            --variant ${DRAM_CHECK_VARIANT}
+    COMMENT "Checking DRAM budget"
+    VERBATIM
+)

--- a/main/feature_flags.h
+++ b/main/feature_flags.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// Build-time feature flags for Mini-FT8.
+//
+// Override at cmake time:
+//   idf.py build -DENABLE_FT4=OFF    # FT8-only, no mode-switch menu item
+//   idf.py build -DENABLE_BLE=OFF    # disable BLE regardless of protocol
+// ---------------------------------------------------------------------------
+
+// ── 1. Protocol support ───────────────────────────────────────────────────────
+//
+// ENABLE_FT4 — include FT4 protocol code and the runtime Mode menu item.
+// Default ON (set by CMakeLists.txt).  When ON, the user can select FT8 or
+// FT4 from Settings → Mode; the choice is saved to Station.txt and applied
+// at next boot.
+//
+// When OFF, only FT8 is available and no Mode menu item is shown.
+#ifndef ENABLE_FT4
+#define ENABLE_FT4 1
+#endif
+
+// ── 2. Optional features ─────────────────────────────────────────────────────
+
+// ENABLE_BLE — compile in NimBLE controller + GATT UI service.
+// Both BLE and FT4 code are compiled into the same binary by default.
+// Runtime enforcement: if the user has selected FT4 mode in Station.txt,
+// BLE initialisation is skipped at boot (NimBLE consumes ~50 KB DRAM that
+// the FT4 LDPC decoder needs).  See apply_ble_enabled_policy() in main.cpp.
+#ifndef ENABLE_BLE
+#define ENABLE_BLE 1
+#endif
+

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -75,7 +75,7 @@ static sdmmc_card_t* g_sd_card = NULL;
 static bool g_sd_mounted = false;
 static bool g_ble_enabled = true;
 
-#define ENABLE_BLE 1
+#include "feature_flags.h"
 
 #if ENABLE_BLE
 #include "nimble/nimble_port.h"

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -6043,6 +6043,13 @@ static bool    g_qmx_detect_active     = false;
 static int64_t g_qmx_detect_deadline_ms = 0;
 static constexpr int64_t kQmxDetectTimeoutMs = 10000;
 
+// CDC-FAIL watchdog: armed when UAC audio comes up (QMX mic detected) but CAT
+// CDC hasn't connected yet. Fires 10 s later; if CDC is still absent, logs a
+// warning (JTAG serial is still up even when USB host mode blocks CDC).
+static bool    g_cdc_check_active      = false;
+static int64_t g_cdc_check_deadline_ms = 0;
+static constexpr int64_t kCdcCheckDelayMs = 10000;
+
 // Switch to MSC (USB Mass Storage) mode. This is a one-way transition:
 // BLE controller memory is released and USB-OTG is re-claimed as a device
 // port until reboot.
@@ -6345,6 +6352,21 @@ autoseq_set_cabrillo_fd_callback(log_cabrillo_fd_entry);
   ui_mode = UIMode::RX;
   load_station_data();
   init_bluetooth();
+  // Boot-time DRAM headroom check. NimBLE can consume ~50 KB of internal DRAM;
+  // if free DIRAM falls below 30 KB after init the CDC-ACM allocator will likely
+  // fail silently when the QMX enumerates. Surface this immediately on the startup
+  // screen (visible without a serial connection) so the failure mode is obvious.
+  {
+    size_t free_diram = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    constexpr size_t kDiramWarnThresholdBytes = 30 * 1024;
+    if (free_diram < kDiramWarnThresholdBytes) {
+      char warn[32];
+      snprintf(warn, sizeof(warn), "LOW DRAM: %u KB", (unsigned)(free_diram / 1024));
+      ESP_LOGW(TAG, "%s (MALLOC_CAP_INTERNAL|8BIT) — CDC-ACM may fail to allocate", warn);
+      g_startup_lines.push_back(warn);
+      ui_draw_debug(g_startup_lines, 0);  // repaint splash with the warning appended
+    }
+  }
   apply_ble_enabled_policy(true);
   apply_radio_profile_binding();
   update_autoseq_cq_type();
@@ -6558,6 +6580,13 @@ autoseq_set_cabrillo_fd_callback(log_cabrillo_fd_entry);
       if (audio_source_qmx_detected()) {
         g_qmx_detect_active = false;
         ESP_LOGI(TAG, "QMX detected; staying in USB host mode");
+        // Arm CDC-FAIL watchdog: if CAT CDC doesn't connect within 10 s of
+        // audio coming up, log a warning (suggests CDC-ACM allocation failure,
+        // often caused by DRAM pressure from NimBLE).
+        if (!cat_cdc_ready()) {
+          g_cdc_check_deadline_ms = esp_timer_get_time() / 1000 + kCdcCheckDelayMs;
+          g_cdc_check_active = true;
+        }
       } else if (esp_timer_get_time() / 1000 >= g_qmx_detect_deadline_ms) {
         if (storage_supports_msc()) {
           enter_msc_mode("no QMX after 10s");
@@ -6565,6 +6594,20 @@ autoseq_set_cabrillo_fd_callback(log_cabrillo_fd_entry);
           g_qmx_detect_active = false;
           ESP_LOGI(TAG, "No QMX detected after 10s — staying in RX (MSC unavailable on launcher install)");
         }
+      }
+    }
+
+    // CDC-FAIL watchdog: fires 10 s after QMX audio enumerated without CAT CDC.
+    // Clears once CDC connects (normal case) or after the warning fires once.
+    if (g_cdc_check_active) {
+      if (cat_cdc_ready()) {
+        g_cdc_check_active = false;  // connected normally, all good
+      } else if (esp_timer_get_time() / 1000 >= g_cdc_check_deadline_ms) {
+        g_cdc_check_active = false;
+        size_t free_diram = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+        ESP_LOGW(TAG, "CDC FAIL: CAT CDC not ready 10s after QMX audio connect "
+                      "(free DIRAM=%u KB) — likely CDC-ACM allocation failure due to DRAM pressure",
+                      (unsigned)(free_diram / 1024));
       }
     }
 

--- a/tools/check_dram_budget.py
+++ b/tools/check_dram_budget.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+check_dram_budget.py — POST_BUILD DRAM headroom checker for Mini-FT8.
+
+Usage (standalone):
+    python tools/check_dram_budget.py <build_dir> [--variant ft8|ft4]
+
+Hooked automatically as a CMake POST_BUILD step via main/CMakeLists.txt.
+
+Exit codes:
+    0  — DRAM budget passes (or idf-size data unavailable — non-fatal)
+    1  — DRAM budget exceeded; build should fail
+
+Variant thresholds:
+    ft8   50 KB free DIRAM  (NimBLE on, tighter headroom)
+    ft4   60 KB free DIRAM  (NimBLE off, more headroom expected)
+
+The thresholds exist to catch silent CDC-ACM allocation failures caused by
+NimBLE consuming DRAM at runtime. The FT8 variant failed in exactly this way
+during development: NimBLE consumed enough DRAM to prevent CDC-ACM from
+allocating its transfer buffers, causing QMX TX to silently not work.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+THRESHOLDS = {
+    "ft8": 50 * 1024,   # 50 KB — BLE on
+    "ft4": 60 * 1024,   # 60 KB — BLE off
+}
+
+DEFAULT_VARIANT = "ft8"
+
+
+def run_idf_size(build_dir: Path) -> dict | None:
+    """Run `idf.py size --format json` and return parsed JSON, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["idf.py", "-B", str(build_dir), "size", "--format", "json"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            print(f"[check_dram_budget] idf.py size failed (rc={result.returncode}); skipping check.")
+            return None
+        return json.loads(result.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError) as e:
+        print(f"[check_dram_budget] Could not run idf.py size: {e}; skipping check.")
+        return None
+
+
+def get_free_diram(size_data: dict) -> int | None:
+    """
+    Extract free DIRAM bytes from idf-size JSON output.
+
+    idf-size JSON structure (IDF >= v5):
+        {"targets": {"esp32s3": {"memories": {"dram0_0_seg": {"used": N, "total": N}}}}}
+    We sum all segments whose key contains "dram" and compute total - used.
+    Falls back to legacy flat structure if nested form is absent.
+    """
+    try:
+        # Modern nested form
+        for target in size_data.get("targets", {}).values():
+            memories = target.get("memories", {})
+            total_used = 0
+            total_size = 0
+            for seg_name, seg in memories.items():
+                if "dram" in seg_name.lower():
+                    total_used += seg.get("used", 0)
+                    total_size += seg.get("total", 0)
+            if total_size > 0:
+                return total_size - total_used
+
+        # Legacy flat form: {"dram_0": {"used": N, "total": N}, ...}
+        total_used = 0
+        total_size = 0
+        for key, val in size_data.items():
+            if "dram" in key.lower() and isinstance(val, dict):
+                total_used += val.get("used", 0)
+                total_size += val.get("total", 0)
+        if total_size > 0:
+            return total_size - total_used
+
+    except Exception as e:
+        print(f"[check_dram_budget] Error parsing size JSON: {e}")
+
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("build_dir", nargs="?", default="build",
+                        help="CMake build directory (default: build)")
+    parser.add_argument("--variant", choices=list(THRESHOLDS.keys()),
+                        default=DEFAULT_VARIANT,
+                        help=f"Build variant (default: {DEFAULT_VARIANT})")
+    args = parser.parse_args()
+
+    build_dir = Path(args.build_dir).resolve()
+    threshold = THRESHOLDS[args.variant]
+
+    print(f"[check_dram_budget] variant={args.variant}  threshold={threshold // 1024} KB free DIRAM")
+
+    size_data = run_idf_size(build_dir)
+    if size_data is None:
+        print("[check_dram_budget] WARNING: could not determine DRAM usage — check skipped (non-fatal).")
+        return 0
+
+    free_diram = get_free_diram(size_data)
+    if free_diram is None:
+        print("[check_dram_budget] WARNING: could not parse DRAM segment data — check skipped (non-fatal).")
+        return 0
+
+    free_kb = free_diram / 1024
+    print(f"[check_dram_budget] static free DIRAM: {free_kb:.1f} KB  (threshold: {threshold // 1024} KB)")
+
+    if free_diram < threshold:
+        print(
+            f"[check_dram_budget] FAIL: only {free_kb:.1f} KB static free DIRAM — "
+            f"below {threshold // 1024} KB threshold for {args.variant} variant.\n"
+            f"  NimBLE + CDC-ACM at runtime will likely exhaust DIRAM.\n"
+            f"  Reduce static allocations or disable unused features."
+        )
+        return 1
+
+    print(f"[check_dram_budget] OK: {free_kb:.1f} KB >= {threshold // 1024} KB threshold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
OK I've tested this locally now specifically with this partial merge that doesn't change the stream stack that was failing. Next change that actually implements ft4 has the required dynamic stack sizing required given ble and ft4 can't currently coexist.

Added a handy ram checker that can run post-build for regression checking to catch likely crash failure modes.

Weirdly I still don't have a working keyboard, but it runs and auto-connects without the keyboard. 