### PR TITLE
Fix menu display, LoRa GPS UART input, and station config persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Mini-FT8 is built on Karlis Goba’s ft8_lib. It’s also a joint adventure betw
 | `G` | GPS | View GPS telemetry and synchronization status. |
 | `M` | MENU P1 | Configure core station and operator settings. |
 | `N` | MENU P2 | Configure radio, input, and comment settings. |
-| `O` | MENU P3 | Configure logging, active bands, GNSS LoRa GPS, copy-to-SD, and retry settings. |
+| `O` | MENU P3 | Configure logging, bands, LoRa GPS, copy-to-SD, and retry settings. |
 | `Q` | QSO | Browse QSO and log files, and view entries. |
 | `D` | Delete Files | Browse and delete files stored in internal FATFS. |
 | `B` | BAND | Edit per-band frequencies. |
@@ -88,7 +88,7 @@ Mini-FT8 is built on Karlis Goba’s ft8_lib. It’s also a joint adventure betw
 | `O` (MENU P3) | `1` | Turn RxTx log on/off. Note: RxTxLog has been renamed to `RT[YYMMDD].txt`. |
 |  | `2` | Turn SkipTX1 on/off. Skips `dxcall mycall mygrid` and replies with the SNR report. |
 |  | `3` | Edit active bands (Long Edit). Used by STATUS -> Band. |
-|  | `4` | Toggle `GNSS_LoRa`. `OFF` uses PORTA GPS; `ON` uses the LoRa-1262 cap GNSS. |
+|  | `4` | Toggle `LoRa GPS`. `OFF` uses PORTA GPS; `ON` uses the LoRa-1262 cap GPS. |
 |  | `5` | Copy files to SD. Feedback is `Copied OK` or `Missed [n]`. |
 |  | `6` | Edit max retry (in place). Accepts any natural number or `0`. |
 | `Q` (QSO) | `1..6` | Open the selected ADIF file. |

--- a/components/storage_service/storage_service.cpp
+++ b/components/storage_service/storage_service.cpp
@@ -1028,6 +1028,16 @@ bool storage_sync_station_from_sd() {
     }
     s_station_sync_attempted = true;
 
+    std::string internal_path;
+    struct stat st = {};
+    if (build_path(kStationFile, internal_path) &&
+        stat(internal_path.c_str(), &st) == 0 &&
+        S_ISREG(st.st_mode) &&
+        st.st_size > 0) {
+        ESP_LOGI(TAG, "Internal Station.txt exists; skipping SD import");
+        return true;
+    }
+
     if (mount_sd_locked() != ESP_OK) {
         ESP_LOGI(TAG, "SD not mounted; using internal Station.txt");
         return false;

--- a/components/ui/ui.cpp
+++ b/components/ui/ui.cpp
@@ -22,6 +22,16 @@ static RxDecodeEntry rx_lines[RX_MAX_DECODES];
 static int rx_lines_count = 0;
 static int rx_page = 0;
 static int rx_selected = -1;  // global index into rx_lines
+
+static std::string fit_text_width(std::string text, int max_width) {
+    if (M5.Display.textWidth(text.c_str()) <= max_width) return text;
+    while (!text.empty() && M5.Display.textWidth((text + ">").c_str()) > max_width) {
+        text.pop_back();
+    }
+    if (!text.empty()) text.push_back('>');
+    return text;
+}
+
 struct RxDrawCacheEntry {
     char text[RX_TEXT_MAX];
     bool is_cq;
@@ -439,8 +449,9 @@ void ui_draw_list(const std::vector<std::string>& lines, int page, int highlight
         if (idx < (int)lines.size()) {
             M5.Display.setTextColor(TFT_WHITE, bg);
             M5.Display.setCursor(0, y);
-            M5.Display.printf("%d %s", i + 1, lines[idx].c_str());
-            g_visible_rows[i] = std::to_string(i + 1) + " " + lines[idx];
+            std::string row = fit_text_width(std::to_string(i + 1) + " " + lines[idx], SCREEN_W);
+            M5.Display.print(row.c_str());
+            g_visible_rows[i] = row;
         } else {
             g_visible_rows[i].clear();
         }

--- a/main/core_api.cpp
+++ b/main/core_api.cpp
@@ -51,7 +51,9 @@ void apply_radio_profile_binding();
 void update_autoseq_cq_type();
 void rebuild_active_bands();
 void rebuild_ignore_prefixes();
+void sync_ignore_prefix_text_from_list();
 bool rtc_apply_manual_time_from_strings();
+bool set_manual_grid_config(const std::string& grid);
 
 // Access to ui.cpp (RX list live in ui.cpp's static array).
 int  ui_get_rx_count();
@@ -492,7 +494,14 @@ bool core_cmd_set_call(const std::string& call) {
   return true;
 }
 bool core_cmd_set_grid(const std::string& grid) {
-  if (!apply_config_write([&]{ g_grid = grid; })) return false;
+  bool ok = false;
+  {
+    ConfigGuard g;
+    ok = set_manual_grid_config(grid);
+  }
+  if (!ok) return false;
+  g_config_save_pending = true;
+  core_fire_config_changed();
   autoseq_set_station(g_call, grid_ft8_4(g_grid));
   return true;
 }
@@ -590,8 +599,8 @@ bool core_cmd_ignore_add(const std::string& prefix) {
       if (p == prefix) return true;  // already present
     }
     g_ignore_prefixes.push_back(prefix);
+    sync_ignore_prefix_text_from_list();
   }
-  rebuild_ignore_prefixes();
   g_config_save_pending = true;
   core_fire_config_changed();
   return true;
@@ -603,9 +612,9 @@ bool core_cmd_ignore_remove(const std::string& prefix) {
     for (auto it = g_ignore_prefixes.begin(); it != g_ignore_prefixes.end(); ++it) {
       if (*it == prefix) { g_ignore_prefixes.erase(it); removed = true; break; }
     }
+    if (removed) sync_ignore_prefix_text_from_list();
   }
   if (!removed) return false;
-  rebuild_ignore_prefixes();
   g_config_save_pending = true;
   core_fire_config_changed();
   return true;
@@ -614,8 +623,8 @@ bool core_cmd_ignore_clear() {
   {
     ConfigGuard g;
     g_ignore_prefixes.clear();
+    sync_ignore_prefix_text_from_list();
   }
-  rebuild_ignore_prefixes();
   g_config_save_pending = true;
   core_fire_config_changed();
   return true;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1208,10 +1208,27 @@ static void ensure_usb() {
 }
 
 static bool uart_inject_last_was_cr = false;
-static bool g_debug_uart_pins_enabled = true;
+static bool g_debug_uart_pins_enabled = false;
+static int64_t s_uart_inject_mute_until_ms = 0;
+
+static void drain_console_uart_rx_fifo() {
+  uart_dev_t *hw = UART_LL_GET_HW(0);
+  uint8_t scratch[64];
+  while (uart_ll_get_rxfifo_len(hw) > 0) {
+    uint32_t n = uart_ll_get_rxfifo_len(hw);
+    if (n > sizeof(scratch)) n = sizeof(scratch);
+    uart_ll_read_rxfifo(hw, scratch, n);
+  }
+  if (s_key_inject_queue) xQueueReset(s_key_inject_queue);
+  uart_inject_last_was_cr = false;
+}
 
 static void poll_uart_inject_keys() {
   if (!s_key_inject_queue || !g_debug_uart_pins_enabled) return;
+  if ((esp_timer_get_time() / 1000) < s_uart_inject_mute_until_ms) {
+    drain_console_uart_rx_fifo();
+    return;
+  }
   // Read directly from the console UART FIFO — no driver needed.
   // sdkconfig configures ESP console on UART0 peripheral with custom
   // pins TX=G4, RX=G5 (see CONFIG_ESP_CONSOLE_UART_CUSTOM_NUM_0
@@ -1323,12 +1340,14 @@ static void apply_debug_uart_pin_policy() {
   const gpio_num_t rx = (gpio_num_t)CONFIG_ESP_CONSOLE_UART_RX_GPIO;
   if (enable) {
     uart_set_pin(UART_NUM_0, tx, rx, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
-    uart_inject_last_was_cr = false;
+    gpio_set_pull_mode(rx, GPIO_PULLUP_ONLY);
+    drain_console_uart_rx_fifo();
+    s_uart_inject_mute_until_ms = esp_timer_get_time() / 1000 + 300;
     g_debug_uart_pins_enabled = true;
     ESP_LOGI(TAG, "G4/G5 debug UART enabled");
   } else {
-    if (s_key_inject_queue) xQueueReset(s_key_inject_queue);
-    uart_inject_last_was_cr = false;
+    drain_console_uart_rx_fifo();
+    s_uart_inject_mute_until_ms = esp_timer_get_time() / 1000 + 300;
 #if UART_SCREEN_MIRROR
     g_uart_mirror_pending = false;
 #endif
@@ -3497,8 +3516,8 @@ static void draw_menu_view() {
   // Page 2 content (index 12+)
   lines.push_back(std::string("RxTxLog:") + (g_rxtx_log ? "ON" : "OFF"));
   lines.push_back(std::string("SkipTX1:") + (g_skip_tx1 ? "ON" : "OFF"));
-  lines.push_back(std::string("ActiveBand:") + head_trim(g_active_band_text, 16));
-  lines.push_back(std::string("GNSS_LoRa:") + (g_gnss_lora_enabled ? "ON" : "OFF"));
+  lines.push_back(std::string("Bands:") + head_trim(g_active_band_text, 11));
+  lines.push_back(std::string("LoRa GPS:") + (g_gnss_lora_enabled ? "ON" : "OFF"));
   if (menu_copy_feedback_deadline > 0 && !menu_copy_feedback_text.empty()) {
     lines.push_back(menu_copy_feedback_text);
   } else {
@@ -4672,15 +4691,7 @@ autoseq_set_cabrillo_fd_callback(log_cabrillo_fd_entry);
                UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
   // Drain any stale bytes left in the FIFO from ROM-bootloader time
   // (when UART0 RX was still on its IO_MUX default pin, likely floating).
-  {
-    uart_dev_t *hw = UART_LL_GET_HW(0);
-    uint8_t scratch[64];
-    while (uart_ll_get_rxfifo_len(hw) > 0) {
-      uint32_t n = uart_ll_get_rxfifo_len(hw);
-      if (n > 64) n = 64;
-      uart_ll_read_rxfifo(hw, scratch, n);
-    }
-  }
+  drain_console_uart_rx_fifo();
   apply_debug_uart_pin_policy();
 
   // UI loop

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2005,6 +2005,27 @@ void rebuild_ignore_prefixes() {
   }
 }
 
+void sync_ignore_prefix_text_from_list() {
+  std::vector<std::string> normalized;
+  for (const auto& prefix : g_ignore_prefixes) {
+    std::string norm = normalize_call_token(prefix);
+    if (norm.empty()) continue;
+    if (std::find(normalized.begin(), normalized.end(), norm) == normalized.end()) {
+      normalized.push_back(norm);
+    }
+  }
+
+  std::string text;
+  for (const auto& prefix : normalized) {
+    const size_t needed = text.size() + (text.empty() ? 0 : 1) + prefix.size();
+    if (needed > kIgnorePrefixTextMaxLen) break;
+    if (!text.empty()) text.push_back(' ');
+    text += prefix;
+  }
+  g_ignore_prefix_text = text;
+  rebuild_ignore_prefixes();
+}
+
 static bool ignorelist_matches_normalized_dxcall(const std::string& dxcall_norm) {
   if (dxcall_norm.empty()) return false;
   for (const auto& prefix : g_ignore_prefixes) {
@@ -2144,6 +2165,16 @@ std::string grid_ft8_4(const std::string& grid) {
   const std::string norm = normalize_grid_maidenhead(grid);
   if (norm.size() >= 4) return norm.substr(0, 4);
   return "CM97";
+}
+
+bool set_manual_grid_config(const std::string& grid) {
+  const std::string norm_grid = normalize_grid_maidenhead(grid);
+  if (norm_grid.empty()) return false;
+  g_grid = norm_grid;
+  g_grid_saved_manual = g_grid;
+  g_grid_from_gps = false;
+  g_grid_gps_display8.clear();
+  return true;
 }
 
 static std::string menu_sleep_batt_line() {


### PR DESCRIPTION
## Summary

- Clip menu/list rows to the Cardputer display width and shorten the O-page labels to `Bands` / `LoRa GPS`, preventing long active-band text from wrapping into the next row.
- Drain and briefly mute the console UART key-injection path when the G4/G5 debug UART pins are toggled, preventing stale UART bytes from triggering random menu actions after switching LoRa GPS.
- Prevent an SD card `Station.txt` from overwriting a non-empty internal `Station.txt` on every boot.
- Keep Core API Grid and IgnoreList updates synchronized with the fields that are saved back to `Station.txt`.

## Why

On Cardputer, a long ActiveBand line can exceed the screen width and overlap the next menu row. Also, toggling LoRa GPS can reconfigure the debug UART pins; stale or floating UART RX bytes can then be interpreted as key presses.

For station settings, V2.1b/V2.1d can import `Station.txt` from SD during startup even when internal settings already exist. That can make edited station settings appear to be lost after reboot unless the user manually copies files to SD.

## Testing

- Built and flashed a test firmware with these fixes on Cardputer.
- Confirmed the O-page band display fits four band entries separated by spaces without overlapping the LoRa GPS row.
- Confirmed repeated LoRa GPS toggles no longer cause random menu jumps or unintended actions.
- Confirmed station settings can be edited and persist after reboot while an older SD `Station.txt` is present.
- Confirmed this patch does not include FT891/CP210x experimental changes.
